### PR TITLE
Use cartridge v0.15.0 handler helpers (Input/Bind/Inertia/flash)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,10 @@ All pages MUST use Inertia.js patterns. No exceptions. No fetch() API calls for 
 
 2. **FORMS**: vanilla Inertia protocol + PRG (POST → Redirect → GET)
    - The frontend uses Inertia endpoints and the **vanilla Inertia protocol**: submit with `useForm().post()` / `router.post()`, NOT raw `fetch()`
-   - Inertia sends the body as **JSON**. Go handlers MUST read it with `ctx.BodyParser(&struct{...})`. Fiber's `ctx.FormValue` does **not** read a JSON body — relying on it alone silently drops the data (the handler may still "succeed" with empty values). Accept both if a plain HTML form also posts to the route (FormValue first, BodyParser fallback — see `SystemGeoLiteFormAction`).
-   - Server validates, sets a flash message, then redirects (PRG); flash shown via `props.flash`
+   - Inertia sends the body as **JSON**. Read it with cartridge's content-type-aware helpers — **never** Fiber's `ctx.FormValue` directly (it can't read a JSON body and silently drops the data, so the handler "succeeds" with empty values):
+     - **1–2 string fields → `ctx.Input("name")`**: returns a single value regardless of transport (JSON body, form, route param, query). No struct needed: `email := strings.TrimSpace(ctx.Input("email"))`.
+     - **3+ fields, typed, or a field name that collides with a route param → `ctx.Bind(&in)`**: decodes into a struct (`json:"x"` tags). Bind overlays route params/query over the body, so a body field named `id` on a `:id` route must be tagged `json:"id"` only (no `params:"id"`) to avoid the route value clobbering it.
+   - Server validates, sets a flash message, then redirects (PRG): `return ctx.FlashError("msg").Redirect(path, fiber.StatusFound)`; flash shown via `props.flash`. Render pages with `ctx.Inertia("Component", inertia.Props{...})`.
    - Examples: Settings, Websites, Account, Login, Onboarding
 
 3. **DATA FLOW**:
@@ -204,28 +206,26 @@ const result = await res.json();
 
 // ✅ GOOD: vanilla Inertia protocol (sends a JSON body, gets an Inertia response)
 const form = useForm({ email: "" });
-form.post("/setup/user");   // Go handler reads it via ctx.BodyParser, then redirects (PRG)
+form.post("/setup/user");   // Go handler reads it via ctx.Input/ctx.Bind, then redirects (PRG)
 ```
 
 ### Server Handler Pattern
 
 ```go
-// ✅ GOOD: Inertia page render
+// ✅ GOOD: Inertia page render (ctx.Inertia auto-injects the flash prop)
 func OnboardingPageAction(ctx *cartridge.Context) error {
-    props := inertia.Props{
+    return ctx.Inertia("Onboarding", inertia.Props{
         "step":  session.Step,
         "email": session.Data.Email,
-    }
-    return inertia.RenderPage(ctx.Ctx, "Onboarding", props)
+    })
 }
 
 // ✅ GOOD: PRG form handler
 func OnboardingUserFormAction(ctx *cartridge.Context) error {
-    email := ctx.FormValue("email")
+    email := strings.TrimSpace(ctx.Input("email"))
     // ... validation ...
-    if err != nil {
-        flash.SetFlash(ctx.Ctx, "error", "Invalid email")
-        return ctx.Redirect("/setup", fiber.StatusFound)
+    if email == "" {
+        return ctx.FlashError("Invalid email").Redirect("/setup", fiber.StatusFound)
     }
     // ... save data ...
     return ctx.Redirect("/setup", fiber.StatusFound)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.12
-	github.com/karloscodes/cartridge v0.13.2
+	github.com/karloscodes/cartridge v0.14.0
 	github.com/karloscodes/matcha v0.12.17
 	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/pariz/gountries v0.1.6

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.12
-	github.com/karloscodes/cartridge v0.14.0
+	github.com/karloscodes/cartridge v0.15.0
 	github.com/karloscodes/matcha v0.12.17
 	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/pariz/gountries v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/karloscodes/cartridge v0.13.2 h1:NgE+uvI9U5ixco9sSzo+S71JWVp8G0sbBCixHMhjuSs=
-github.com/karloscodes/cartridge v0.13.2/go.mod h1:jwNv+4v57uydGfREtRWUaWSudhf+oWu92JAOxlK8O9o=
+github.com/karloscodes/cartridge v0.14.0 h1:OUNSJfhrbcOIen5KBLTLpiyT1Bq0P5KLDjMl6tOqnMY=
+github.com/karloscodes/cartridge v0.14.0/go.mod h1:jwNv+4v57uydGfREtRWUaWSudhf+oWu92JAOxlK8O9o=
 github.com/karloscodes/matcha v0.12.17 h1:DChFQxQSKd9dU7M2GO3N023oVrNIjQGX624v8IB2yDo=
 github.com/karloscodes/matcha v0.12.17/go.mod h1:Zpy+ZfP/5OQMfdChOxzxP++m1mBFWJiXPjt3yYsCb9g=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/karloscodes/cartridge v0.14.0 h1:OUNSJfhrbcOIen5KBLTLpiyT1Bq0P5KLDjMl6tOqnMY=
-github.com/karloscodes/cartridge v0.14.0/go.mod h1:jwNv+4v57uydGfREtRWUaWSudhf+oWu92JAOxlK8O9o=
+github.com/karloscodes/cartridge v0.15.0 h1:ZkrveiX6Ha7kpJh4fcPUQWvLIiDHR1lNxak99XOcgDM=
+github.com/karloscodes/cartridge v0.15.0/go.mod h1:jwNv+4v57uydGfREtRWUaWSudhf+oWu92JAOxlK8O9o=
 github.com/karloscodes/matcha v0.12.17 h1:DChFQxQSKd9dU7M2GO3N023oVrNIjQGX624v8IB2yDo=
 github.com/karloscodes/matcha v0.12.17/go.mod h1:Zpy+ZfP/5OQMfdChOxzxP++m1mBFWJiXPjt3yYsCb9g=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=

--- a/internal/http/account_handler.go
+++ b/internal/http/account_handler.go
@@ -13,8 +13,13 @@ import (
 
 // AccountChangePasswordFormAction handles POST form submission for password change (Inertia)
 func AccountChangePasswordFormAction(ctx *cartridge.Context) error {
-	currentPassword := ctx.FormValue("current_password")
-	newPassword := ctx.FormValue("new_password")
+	var in struct {
+		CurrentPassword string `json:"current_password" form:"current_password"`
+		NewPassword     string `json:"new_password" form:"new_password"`
+	}
+	_ = ctx.Bind(&in)
+	currentPassword := in.CurrentPassword
+	newPassword := in.NewPassword
 
 	// Get current user ID from session
 	userID, authenticated := ctx.Session.GetUserID(ctx.Ctx)

--- a/internal/http/account_handler.go
+++ b/internal/http/account_handler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/karloscodes/cartridge"
 	"github.com/karloscodes/cartridge/crypto"
-	"github.com/karloscodes/cartridge/flash"
 	"log/slog"
 
 	"fusionaly/internal/users"
@@ -20,24 +19,20 @@ func AccountChangePasswordFormAction(ctx *cartridge.Context) error {
 	// Get current user ID from session
 	userID, authenticated := ctx.Session.GetUserID(ctx.Ctx)
 	if !authenticated {
-		flash.SetFlash(ctx.Ctx, "error", "Authentication required")
-		return ctx.Redirect("/admin/administration/account", fiber.StatusFound)
+		return ctx.FlashError("Authentication required").Redirect("/admin/administration/account", fiber.StatusFound)
 	}
 
 	// Validate input
 	if strings.TrimSpace(currentPassword) == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Current password is required")
-		return ctx.Redirect("/admin/administration/account", fiber.StatusFound)
+		return ctx.FlashError("Current password is required").Redirect("/admin/administration/account", fiber.StatusFound)
 	}
 
 	if strings.TrimSpace(newPassword) == "" {
-		flash.SetFlash(ctx.Ctx, "error", "New password is required")
-		return ctx.Redirect("/admin/administration/account", fiber.StatusFound)
+		return ctx.FlashError("New password is required").Redirect("/admin/administration/account", fiber.StatusFound)
 	}
 
 	if len(newPassword) < 8 {
-		flash.SetFlash(ctx.Ctx, "error", "New password must be at least 8 characters long")
-		return ctx.Redirect("/admin/administration/account", fiber.StatusFound)
+		return ctx.FlashError("New password must be at least 8 characters long").Redirect("/admin/administration/account", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -46,27 +41,23 @@ func AccountChangePasswordFormAction(ctx *cartridge.Context) error {
 	user, err := users.FindByID(db, userID)
 	if err != nil {
 		ctx.Logger.Error("Failed to find user for password change", slog.Uint64("userID", uint64(userID)), slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "User not found")
-		return ctx.Redirect("/admin/administration/account", fiber.StatusFound)
+		return ctx.FlashError("User not found").Redirect("/admin/administration/account", fiber.StatusFound)
 	}
 
 	// Verify current password
 	if !crypto.VerifyPassword(user.EncryptedPassword, currentPassword) {
 		ctx.Logger.Warn("Invalid current password provided during password change", slog.Uint64("userID", uint64(userID)))
-		flash.SetFlash(ctx.Ctx, "error", "Current password is incorrect")
-		return ctx.Redirect("/admin/administration/account", fiber.StatusFound)
+		return ctx.FlashError("Current password is incorrect").Redirect("/admin/administration/account", fiber.StatusFound)
 	}
 
 	// Change password
 	if err := users.ChangePassword(db, user.Email, newPassword); err != nil {
 		ctx.Logger.Error("Failed to change password", slog.Uint64("userID", uint64(userID)), slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to change password")
-		return ctx.Redirect("/admin/administration/account", fiber.StatusFound)
+		return ctx.FlashError("Failed to change password").Redirect("/admin/administration/account", fiber.StatusFound)
 	}
 
 	ctx.Logger.Info("Password changed successfully", slog.Uint64("userID", uint64(userID)), slog.String("email", user.Email))
-	flash.SetFlash(ctx.Ctx, "success", "Password changed successfully")
-	return ctx.Redirect("/admin/administration/account", fiber.StatusFound)
+	return ctx.FlashSuccess("Password changed successfully").Redirect("/admin/administration/account", fiber.StatusFound)
 }
 
 // Note: Fusionaly has no license/seat model. The former Pro license handlers

--- a/internal/http/account_handler.go
+++ b/internal/http/account_handler.go
@@ -13,13 +13,8 @@ import (
 
 // AccountChangePasswordFormAction handles POST form submission for password change (Inertia)
 func AccountChangePasswordFormAction(ctx *cartridge.Context) error {
-	var in struct {
-		CurrentPassword string `json:"current_password" form:"current_password"`
-		NewPassword     string `json:"new_password" form:"new_password"`
-	}
-	_ = ctx.Bind(&in)
-	currentPassword := in.CurrentPassword
-	newPassword := in.NewPassword
+	currentPassword := ctx.Input("current_password")
+	newPassword := ctx.Input("new_password")
 
 	// Get current user ID from session
 	userID, authenticated := ctx.Session.GetUserID(ctx.Ctx)

--- a/internal/http/ai_settings_handler.go
+++ b/internal/http/ai_settings_handler.go
@@ -39,13 +39,9 @@ func AISettingsFormAction(ctx *cartridge.Context) error {
 	db := ctx.DB()
 
 	// The frontend posts via the vanilla Inertia protocol (useForm/router.post),
-	// which sends a JSON body that FormValue can't read. Bind is content-type
+	// which sends a JSON body that FormValue can't read. Input is content-type
 	// aware: it reads JSON or form-encoded bodies (same as the geolite form).
-	var in struct {
-		OpenAIKey string `json:"openai_api_key" form:"openai_api_key"`
-	}
-	_ = ctx.Bind(&in)
-	openAIKey := strings.TrimSpace(in.OpenAIKey)
+	openAIKey := strings.TrimSpace(ctx.Input("openai_api_key"))
 
 	// Don't save masked keys (user didn't change the existing value)
 	if strings.HasPrefix(openAIKey, "****") {

--- a/internal/http/ai_settings_handler.go
+++ b/internal/http/ai_settings_handler.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/karloscodes/cartridge"
-	"github.com/karloscodes/cartridge/flash"
 	"github.com/karloscodes/cartridge/inertia"
 
 	"fusionaly/internal/settings"
@@ -30,7 +29,7 @@ func AISettingsPageAction(ctx *cartridge.Context) error {
 		},
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "AdministrationAI", inertia.Props{
+	return ctx.Inertia("AdministrationAI", inertia.Props{
 		"settings": settingsData,
 	})
 }
@@ -40,22 +39,17 @@ func AISettingsFormAction(ctx *cartridge.Context) error {
 	db := ctx.DB()
 
 	// The frontend posts via the vanilla Inertia protocol (useForm/router.post),
-	// which sends a JSON body that FormValue can't read. Try form-encoded first,
-	// then fall back to the Inertia JSON body (same as the geolite form).
-	openAIKey := strings.TrimSpace(ctx.FormValue("openai_api_key"))
-	if openAIKey == "" {
-		var body struct {
-			OpenAIKey string `json:"openai_api_key"`
-		}
-		if err := ctx.BodyParser(&body); err == nil {
-			openAIKey = strings.TrimSpace(body.OpenAIKey)
-		}
+	// which sends a JSON body that FormValue can't read. Bind is content-type
+	// aware: it reads JSON or form-encoded bodies (same as the geolite form).
+	var in struct {
+		OpenAIKey string `json:"openai_api_key" form:"openai_api_key"`
 	}
+	_ = ctx.Bind(&in)
+	openAIKey := strings.TrimSpace(in.OpenAIKey)
 
 	// Don't save masked keys (user didn't change the existing value)
 	if strings.HasPrefix(openAIKey, "****") {
-		flash.SetFlash(ctx.Ctx, "info", "No changes made to AI settings")
-		return ctx.Redirect("/admin/administration/ai", fiber.StatusFound)
+		return ctx.FlashInfo("No changes made to AI settings").Redirect("/admin/administration/ai", fiber.StatusFound)
 	}
 
 	if openAIKey != "" {
@@ -64,11 +58,9 @@ func AISettingsFormAction(ctx *cartridge.Context) error {
 		// require a non-empty key, which is already guaranteed here.
 		if err := settings.SaveOpenAIKey(db, openAIKey); err != nil {
 			ctx.Logger.Error("Failed to save OpenAI API key")
-			flash.SetFlash(ctx.Ctx, "error", "Failed to save AI settings")
-			return ctx.Redirect("/admin/administration/ai", fiber.StatusFound)
+			return ctx.FlashError("Failed to save AI settings").Redirect("/admin/administration/ai", fiber.StatusFound)
 		}
 	}
 
-	flash.SetFlash(ctx.Ctx, "success", "AI settings saved successfully")
-	return ctx.Redirect("/admin/administration/ai", fiber.StatusFound)
+	return ctx.FlashSuccess("AI settings saved successfully").Redirect("/admin/administration/ai", fiber.StatusFound)
 }

--- a/internal/http/annotations_handler.go
+++ b/internal/http/annotations_handler.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"log/slog"
 	"gorm.io/gorm"
+	"log/slog"
 
 	"fusionaly/internal/annotations"
 	"github.com/karloscodes/cartridge"
@@ -22,44 +22,24 @@ type annotationFormData struct {
 	Color          string
 }
 
-// parseAnnotationForm extracts annotation data from form values or JSON body
+// parseAnnotationForm extracts annotation data from form values or JSON body.
+// Bind is content-type aware (form-encoded or Inertia.js JSON).
 func parseAnnotationForm(ctx *cartridge.Context) annotationFormData {
-	data := annotationFormData{
-		Title:          ctx.FormValue("title"),
-		Description:    ctx.FormValue("description"),
-		AnnotationType: ctx.FormValue("annotation_type"),
-		AnnotationDate: ctx.FormValue("annotation_date"),
-		Color:          ctx.FormValue("color"),
+	var in struct {
+		Title          string `json:"title" form:"title"`
+		Description    string `json:"description" form:"description"`
+		AnnotationType string `json:"annotation_type" form:"annotation_type"`
+		AnnotationDate string `json:"annotation_date" form:"annotation_date"`
+		Color          string `json:"color" form:"color"`
 	}
-
-	// Try parsing as JSON for Inertia.js requests
-	if data.Title == "" {
-		var jsonBody struct {
-			Title          string `json:"title"`
-			Description    string `json:"description"`
-			AnnotationType string `json:"annotation_type"`
-			AnnotationDate string `json:"annotation_date"`
-			Color          string `json:"color"`
-		}
-		if err := ctx.BodyParser(&jsonBody); err == nil {
-			if jsonBody.Title != "" {
-				data.Title = jsonBody.Title
-			}
-			if jsonBody.Description != "" {
-				data.Description = jsonBody.Description
-			}
-			if jsonBody.AnnotationType != "" {
-				data.AnnotationType = jsonBody.AnnotationType
-			}
-			if jsonBody.AnnotationDate != "" {
-				data.AnnotationDate = jsonBody.AnnotationDate
-			}
-			if jsonBody.Color != "" {
-				data.Color = jsonBody.Color
-			}
-		}
+	_ = ctx.Bind(&in)
+	return annotationFormData{
+		Title:          in.Title,
+		Description:    in.Description,
+		AnnotationType: in.AnnotationType,
+		AnnotationDate: in.AnnotationDate,
+		Color:          in.Color,
 	}
-	return data
 }
 
 // annotationDateFormats defines accepted date formats for annotation dates
@@ -142,8 +122,7 @@ func AnnotationCreateAction(ctx *cartridge.Context) error {
 	websiteID, err := ctx.ParamsInt("id")
 	if err != nil {
 		ctx.Logger.Error("Invalid website ID", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin", fiber.StatusFound)
 	}
 
 	form := parseAnnotationForm(ctx)
@@ -158,20 +137,17 @@ func AnnotationCreateAction(ctx *cartridge.Context) error {
 
 	// Validate required fields
 	if form.Title == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Title is required")
-		return ctx.Redirect(redirectPath, fiber.StatusFound)
+		return ctx.FlashError("Title is required").Redirect(redirectPath, fiber.StatusFound)
 	}
 
 	if form.AnnotationDate == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Date is required")
-		return ctx.Redirect(redirectPath, fiber.StatusFound)
+		return ctx.FlashError("Date is required").Redirect(redirectPath, fiber.StatusFound)
 	}
 
 	annotationDate, ok := parseAnnotationDate(form.AnnotationDate)
 	if !ok {
 		ctx.Logger.Error("Failed to parse annotation date", slog.String("date", form.AnnotationDate))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid date format")
-		return ctx.Redirect(redirectPath, fiber.StatusFound)
+		return ctx.FlashError("Invalid date format").Redirect(redirectPath, fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -192,8 +168,7 @@ func AnnotationCreateAction(ctx *cartridge.Context) error {
 
 	if err := annotations.CreateAnnotation(db, annotation); err != nil {
 		ctx.Logger.Error("Failed to create annotation", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to create annotation")
-		return ctx.Redirect(redirectPath, fiber.StatusFound)
+		return ctx.FlashError("Failed to create annotation").Redirect(redirectPath, fiber.StatusFound)
 	}
 
 	ctx.Logger.Info("Annotation created successfully",
@@ -201,8 +176,7 @@ func AnnotationCreateAction(ctx *cartridge.Context) error {
 		slog.Int("websiteID", websiteID),
 	)
 
-	flash.SetFlash(ctx.Ctx, "success", "Annotation created successfully")
-	return ctx.Redirect(redirectPath, fiber.StatusFound)
+	return ctx.FlashSuccess("Annotation created successfully").Redirect(redirectPath, fiber.StatusFound)
 }
 
 // AnnotationUpdateAction updates an existing annotation (form submission)
@@ -210,8 +184,7 @@ func AnnotationUpdateAction(ctx *cartridge.Context) error {
 	websiteID, err := ctx.ParamsInt("id")
 	if err != nil {
 		ctx.Logger.Error("Invalid website ID", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin", fiber.StatusFound)
 	}
 
 	redirectPath := dashboardPath(websiteID)
@@ -219,8 +192,7 @@ func AnnotationUpdateAction(ctx *cartridge.Context) error {
 	annotationID, err := ctx.ParamsInt("annotationId")
 	if err != nil {
 		ctx.Logger.Error("Invalid annotation ID", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid annotation ID")
-		return ctx.Redirect(redirectPath, fiber.StatusFound)
+		return ctx.FlashError("Invalid annotation ID").Redirect(redirectPath, fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -239,8 +211,7 @@ func AnnotationUpdateAction(ctx *cartridge.Context) error {
 	form := parseAnnotationForm(ctx)
 
 	if form.Title == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Title is required")
-		return ctx.Redirect(redirectPath, fiber.StatusFound)
+		return ctx.FlashError("Title is required").Redirect(redirectPath, fiber.StatusFound)
 	}
 
 	// Update fields
@@ -260,8 +231,7 @@ func AnnotationUpdateAction(ctx *cartridge.Context) error {
 
 	if err := annotations.UpdateAnnotation(db, existing); err != nil {
 		ctx.Logger.Error("Failed to update annotation", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to update annotation")
-		return ctx.Redirect(redirectPath, fiber.StatusFound)
+		return ctx.FlashError("Failed to update annotation").Redirect(redirectPath, fiber.StatusFound)
 	}
 
 	ctx.Logger.Info("Annotation updated successfully",
@@ -269,8 +239,7 @@ func AnnotationUpdateAction(ctx *cartridge.Context) error {
 		slog.Int("websiteID", websiteID),
 	)
 
-	flash.SetFlash(ctx.Ctx, "success", "Annotation updated successfully")
-	return ctx.Redirect(redirectPath, fiber.StatusFound)
+	return ctx.FlashSuccess("Annotation updated successfully").Redirect(redirectPath, fiber.StatusFound)
 }
 
 // AnnotationDeleteAction deletes an annotation (form submission)
@@ -278,8 +247,7 @@ func AnnotationDeleteAction(ctx *cartridge.Context) error {
 	websiteID, err := ctx.ParamsInt("id")
 	if err != nil {
 		ctx.Logger.Error("Invalid website ID", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin", fiber.StatusFound)
 	}
 
 	redirectPath := dashboardPath(websiteID)
@@ -287,8 +255,7 @@ func AnnotationDeleteAction(ctx *cartridge.Context) error {
 	annotationID, err := ctx.ParamsInt("annotationId")
 	if err != nil {
 		ctx.Logger.Error("Invalid annotation ID", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid annotation ID")
-		return ctx.Redirect(redirectPath, fiber.StatusFound)
+		return ctx.FlashError("Invalid annotation ID").Redirect(redirectPath, fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -308,6 +275,5 @@ func AnnotationDeleteAction(ctx *cartridge.Context) error {
 		slog.Int("websiteID", websiteID),
 	)
 
-	flash.SetFlash(ctx.Ctx, "success", "Annotation deleted successfully")
-	return ctx.Redirect(redirectPath, fiber.StatusFound)
+	return ctx.FlashSuccess("Annotation deleted successfully").Redirect(redirectPath, fiber.StatusFound)
 }

--- a/internal/http/dashboard_handler.go
+++ b/internal/http/dashboard_handler.go
@@ -9,12 +9,11 @@ import (
 
 	"fusionaly/internal/analytics"
 	"fusionaly/internal/annotations"
-	"github.com/karloscodes/cartridge"
-	"github.com/karloscodes/cartridge/flash"
-	"github.com/karloscodes/cartridge/inertia"
-	"github.com/karloscodes/cartridge/structs"
 	"fusionaly/internal/timeframe"
 	websitesCtx "fusionaly/internal/websites"
+	"github.com/karloscodes/cartridge"
+	"github.com/karloscodes/cartridge/inertia"
+	"github.com/karloscodes/cartridge/structs"
 
 	"gorm.io/gorm"
 )
@@ -33,8 +32,7 @@ func WebsiteDashboardAction(ctx *cartridge.Context) error {
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			ctx.Logger.Warn("Website not found", slog.Int("websiteId", websiteId))
-			flash.SetFlash(ctx.Ctx, "error", "Website not found")
-			return ctx.Redirect("/admin/websites", fiber.StatusFound)
+			return ctx.FlashError("Website not found").Redirect("/admin/websites", fiber.StatusFound)
 		}
 		ctx.Logger.Error("Failed to get website", slog.Any("error", err))
 		return ctx.Redirect("/admin/websites", fiber.StatusFound)
@@ -120,5 +118,5 @@ func WebsiteDashboardAction(ctx *cartridge.Context) error {
 		return flowData
 	})
 
-	return inertia.RenderPage(ctx.Ctx, "Dashboard", props)
+	return ctx.Inertia("Dashboard", props)
 }

--- a/internal/http/events_handler.go
+++ b/internal/http/events_handler.go
@@ -5,16 +5,14 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"log/slog"
 	"gorm.io/gorm"
+	"log/slog"
 
 	"fusionaly/internal/events"
-	"github.com/karloscodes/cartridge"
-	"github.com/karloscodes/cartridge/flash"
-	"github.com/karloscodes/cartridge/inertia"
-	"github.com/karloscodes/cartridge/structs"
 	"fusionaly/internal/visitors"
 	"fusionaly/internal/websites"
+	"github.com/karloscodes/cartridge"
+	"github.com/karloscodes/cartridge/structs"
 )
 
 type PaginationData struct {
@@ -56,8 +54,7 @@ func EventsIndexAction(ctx *cartridge.Context) error {
 				return ctx.Redirect("/admin/websites/new", fiber.StatusFound)
 			}
 			ctx.Logger.Error("Failed to get first website", slog.Any("error", err))
-			flash.SetFlash(ctx.Ctx, "error", "Error getting website data")
-			return ctx.Redirect("/admin/websites", fiber.StatusFound)
+			return ctx.FlashError("Error getting website data").Redirect("/admin/websites", fiber.StatusFound)
 		}
 
 		ctx.Logger.Info("Found first website", slog.Uint64("id", uint64(firstWebsite.ID)), slog.String("domain", firstWebsite.Domain))
@@ -95,8 +92,7 @@ func EventsIndexAction(ctx *cartridge.Context) error {
 	})
 	if err != nil {
 		ctx.Logger.Error("Failed to fetch events", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to fetch events")
-		return ctx.Redirect("/admin/websites", fiber.StatusFound)
+		return ctx.FlashError("Failed to fetch events").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
 	mappedEvents := make([]Event, len(result.Events))
@@ -127,7 +123,7 @@ func EventsIndexAction(ctx *cartridge.Context) error {
 	props := structs.Map(response)
 	props["current_website_id"] = websiteId
 
-	return inertia.RenderPage(ctx.Ctx, "Events", props)
+	return ctx.Inertia("Events", props)
 }
 
 // calculateDateRange calculates from and to dates based on range filter
@@ -186,8 +182,7 @@ func WebsiteEventsAction(ctx *cartridge.Context) error {
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			ctx.Logger.Warn("Website not found", slog.Int("websiteId", websiteId))
-			flash.SetFlash(ctx.Ctx, "error", "Website not found")
-			return ctx.Redirect("/admin/websites", fiber.StatusFound)
+			return ctx.FlashError("Website not found").Redirect("/admin/websites", fiber.StatusFound)
 		}
 		ctx.Logger.Error("Failed to get website", slog.Any("error", err))
 		return ctx.Redirect("/admin/websites", fiber.StatusFound)
@@ -224,8 +219,7 @@ func WebsiteEventsAction(ctx *cartridge.Context) error {
 	})
 	if err != nil {
 		ctx.Logger.Error("Failed to fetch events", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to fetch events")
-		return ctx.Redirect("/admin/websites", fiber.StatusFound)
+		return ctx.FlashError("Failed to fetch events").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
 	mappedEvents := make([]Event, len(result.Events))
@@ -265,5 +259,5 @@ func WebsiteEventsAction(ctx *cartridge.Context) error {
 	props["website_domain"] = website.Domain
 	props["websites"] = websitesData
 
-	return inertia.RenderPage(ctx.Ctx, "Events", props)
+	return ctx.Inertia("Events", props)
 }

--- a/internal/http/feed_handler.go
+++ b/internal/http/feed_handler.go
@@ -81,7 +81,7 @@ func HomeFeedAction(ctx *cartridge.Context) error {
 	// Visitor calendar (last 365 days, all websites combined).
 	calendarData, totalVisitors := buildVisitorCalendar(db, websiteIDs)
 
-	return inertia.RenderPage(ctx.Ctx, "Home", inertia.Props{
+	return ctx.Inertia("Home", inertia.Props{
 		"feedItems":     enrichedItems,
 		"websites":      websites,
 		"calendarData":  calendarData,

--- a/internal/http/lens_handler.go
+++ b/internal/http/lens_handler.go
@@ -120,9 +120,18 @@ func WebsiteLensAskAIAction(ctx *cartridge.Context) error {
 		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
-	question := ctx.FormValue("query")
+	// Read the question/model from the request body. The route :id is the
+	// website id (read via ctx.Params above); this struct deliberately omits a
+	// params tag so Bind's ParamsParser can't overlay it.
+	var in struct {
+		Query string `json:"query" form:"query"`
+		Model string `json:"model" form:"model"`
+	}
+	_ = ctx.Bind(&in)
+
+	question := in.Query
 	// Empty model lets GetQueryFromOpenAI fall back to ai.DefaultModel.
-	model := ctx.FormValue("model")
+	model := in.Model
 	if question == "" {
 		return ctx.FlashError("Please enter a question").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
@@ -191,11 +200,22 @@ func WebsiteLensSaveAction(ctx *cartridge.Context) error {
 		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
-	title := ctx.FormValue("title")
-	generatedSQL := ctx.FormValue("generated_sql")
-	queryType := ctx.FormValue("query_type")
-	vegaSpec := ctx.FormValue("vega_spec")
-	model := ctx.FormValue("model")
+	// The route :id is the website id (read via ctx.Params above); this struct
+	// deliberately omits a params tag so Bind's ParamsParser can't overlay it.
+	var in struct {
+		Title        string `json:"title" form:"title"`
+		GeneratedSQL string `json:"generated_sql" form:"generated_sql"`
+		QueryType    string `json:"query_type" form:"query_type"`
+		VegaSpec     string `json:"vega_spec" form:"vega_spec"`
+		Model        string `json:"model" form:"model"`
+	}
+	_ = ctx.Bind(&in)
+
+	title := in.Title
+	generatedSQL := in.GeneratedSQL
+	queryType := in.QueryType
+	vegaSpec := in.VegaSpec
+	model := in.Model
 
 	if title == "" || generatedSQL == "" {
 		return ctx.FlashError("Title and SQL are required").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
@@ -226,10 +246,20 @@ func WebsiteLensUpdateAction(ctx *cartridge.Context) error {
 		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
-	queryID, _ := strconv.Atoi(ctx.FormValue("id"))
-	newTitle := ctx.FormValue("title")
+	// in.ID is the saved-query id from the form/body. The route :id is the
+	// website id (read via ctx.Params above); this struct deliberately omits a
+	// params tag so Bind's ParamsParser can't overlay in.ID with the website id.
+	var in struct {
+		ID    string `json:"id" form:"id"`
+		Title string `json:"title" form:"title"`
+		Model string `json:"model" form:"model"`
+	}
+	_ = ctx.Bind(&in)
+
+	queryID, _ := strconv.Atoi(in.ID)
+	newTitle := in.Title
 	// Empty model lets GetQueryFromOpenAI fall back to ai.DefaultModel.
-	model := ctx.FormValue("model")
+	model := in.Model
 
 	if queryID <= 0 || newTitle == "" {
 		return ctx.FlashError("Invalid query ID or title").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
@@ -267,7 +297,15 @@ func WebsiteLensDeleteAction(ctx *cartridge.Context) error {
 		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
-	queryID, _ := strconv.Atoi(ctx.FormValue("id"))
+	// in.ID is the saved-query id from the form/body. The route :id is the
+	// website id (read via ctx.Params above); this struct deliberately omits a
+	// params tag so Bind's ParamsParser can't overlay in.ID with the website id.
+	var in struct {
+		ID string `json:"id" form:"id"`
+	}
+	_ = ctx.Bind(&in)
+
+	queryID, _ := strconv.Atoi(in.ID)
 	if queryID <= 0 {
 		return ctx.FlashError("Invalid query ID").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
@@ -288,7 +326,15 @@ func WebsiteLensCloneAction(ctx *cartridge.Context) error {
 		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
-	queryID, _ := strconv.Atoi(ctx.FormValue("id"))
+	// in.ID is the saved-query id from the form/body. The route :id is the
+	// website id (read via ctx.Params above); this struct deliberately omits a
+	// params tag so Bind's ParamsParser can't overlay in.ID with the website id.
+	var in struct {
+		ID string `json:"id" form:"id"`
+	}
+	_ = ctx.Bind(&in)
+
+	queryID, _ := strconv.Atoi(in.ID)
 	if queryID <= 0 {
 		return ctx.FlashError("Invalid query ID").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}

--- a/internal/http/lens_handler.go
+++ b/internal/http/lens_handler.go
@@ -121,17 +121,11 @@ func WebsiteLensAskAIAction(ctx *cartridge.Context) error {
 	}
 
 	// Read the question/model from the request body. The route :id is the
-	// website id (read via ctx.Params above); this struct deliberately omits a
-	// params tag so Bind's ParamsParser can't overlay it.
-	var in struct {
-		Query string `json:"query" form:"query"`
-		Model string `json:"model" form:"model"`
-	}
-	_ = ctx.Bind(&in)
-
-	question := in.Query
+	// website id (read via ctx.Params above); Input("query"/"model") reads only
+	// those keys, so the :id param can't be overlaid here.
+	question := ctx.Input("query")
 	// Empty model lets GetQueryFromOpenAI fall back to ai.DefaultModel.
-	model := in.Model
+	model := ctx.Input("model")
 	if question == "" {
 		return ctx.FlashError("Please enter a question").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}

--- a/internal/http/lens_handler.go
+++ b/internal/http/lens_handler.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/karloscodes/cartridge"
-	"github.com/karloscodes/cartridge/flash"
 	"github.com/karloscodes/cartridge/inertia"
 	"gorm.io/gorm"
 
@@ -74,8 +73,7 @@ func WebsiteLensAction(ctx *cartridge.Context) error {
 
 	websiteID, err := strconv.Atoi(ctx.Params("id"))
 	if err != nil || websiteID <= 0 {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin/websites", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
 	// Get saved queries for this website
@@ -109,7 +107,7 @@ func WebsiteLensAction(ctx *cartridge.Context) error {
 		"models":             ai.AvailableModels,
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "Lens", props)
+	return ctx.Inertia("Lens", props)
 }
 
 // WebsiteLensAskAIAction handles AI question submission (POST -> Inertia render)
@@ -119,36 +117,31 @@ func WebsiteLensAskAIAction(ctx *cartridge.Context) error {
 	websiteIDStr := ctx.Params("id")
 	websiteID, err := strconv.Atoi(websiteIDStr)
 	if err != nil || websiteID <= 0 {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin/websites", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
 	question := ctx.FormValue("query")
 	// Empty model lets GetQueryFromOpenAI fall back to ai.DefaultModel.
 	model := ctx.FormValue("model")
 	if question == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Please enter a question")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Please enter a question").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	openAIKey, err := ai.GetOpenAIApiKey(db)
 	if err != nil || openAIKey == "" {
-		flash.SetFlash(ctx.Ctx, "error", "OpenAI API key is not configured. Please configure it in AI Settings.")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("OpenAI API key is not configured. Please configure it in AI Settings.").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	aiResult, err := ai.GetQueryFromOpenAI(context.Background(), db, question, openAIKey, websiteID, model, ctx.Logger)
 	if err != nil {
 		ctx.Logger.Error("Failed to get query from OpenAI", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to generate query: "+err.Error())
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Failed to generate query: "+err.Error()).Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	results, err := ai.ExecuteQuery(db, aiResult.SQL, aiResult.QueryType)
 	if err != nil {
 		ctx.Logger.Error("Failed to execute AI query", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Query execution failed: "+err.Error())
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Query execution failed: "+err.Error()).Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	// Cache the successful result (best-effort)
@@ -185,7 +178,7 @@ func WebsiteLensAskAIAction(ctx *cartridge.Context) error {
 		},
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "Lens", props)
+	return ctx.Inertia("Lens", props)
 }
 
 // WebsiteLensSaveAction saves an AI-generated query (POST -> Redirect)
@@ -195,8 +188,7 @@ func WebsiteLensSaveAction(ctx *cartridge.Context) error {
 	websiteIDStr := ctx.Params("id")
 	websiteID, err := strconv.Atoi(websiteIDStr)
 	if err != nil || websiteID <= 0 {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin/websites", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
 	title := ctx.FormValue("title")
@@ -206,26 +198,22 @@ func WebsiteLensSaveAction(ctx *cartridge.Context) error {
 	model := ctx.FormValue("model")
 
 	if title == "" || generatedSQL == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Title and SQL are required")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Title and SQL are required").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	// A saved query re-executes on every Lens load, so validate it as read-only
 	// before persisting — not just at execution time.
 	if err := ai.ValidateReadOnlyQuery(generatedSQL); err != nil {
-		flash.SetFlash(ctx.Ctx, "error", "Only read-only SELECT queries can be saved")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Only read-only SELECT queries can be saved").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	websiteIDUint := uint(websiteID)
 	if _, err := ai.CreateSavedQueryWithVega(db, title, generatedSQL, vegaSpec, &websiteIDUint, queryType, model); err != nil {
 		ctx.Logger.Error("Failed to save query", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to save query")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Failed to save query").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
-	flash.SetFlash(ctx.Ctx, "success", "Query saved successfully")
-	return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+	return ctx.FlashSuccess("Query saved successfully").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 }
 
 // WebsiteLensUpdateAction updates a saved query by regenerating SQL (POST -> Redirect)
@@ -235,8 +223,7 @@ func WebsiteLensUpdateAction(ctx *cartridge.Context) error {
 	websiteIDStr := ctx.Params("id")
 	websiteID, err := strconv.Atoi(websiteIDStr)
 	if err != nil || websiteID <= 0 {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin/websites", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
 	queryID, _ := strconv.Atoi(ctx.FormValue("id"))
@@ -245,37 +232,31 @@ func WebsiteLensUpdateAction(ctx *cartridge.Context) error {
 	model := ctx.FormValue("model")
 
 	if queryID <= 0 || newTitle == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid query ID or title")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Invalid query ID or title").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	savedQuery, err := ai.GetSavedQuery(db, uint(queryID))
 	if err != nil {
-		flash.SetFlash(ctx.Ctx, "error", "Query not found")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Query not found").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	openAIKey, err := ai.GetOpenAIApiKey(db)
 	if err != nil || openAIKey == "" {
-		flash.SetFlash(ctx.Ctx, "error", "OpenAI API key is not configured")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("OpenAI API key is not configured").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	aiResult, err := ai.GetQueryFromOpenAI(context.Background(), db, newTitle, openAIKey, websiteID, model, ctx.Logger)
 	if err != nil {
 		ctx.Logger.Error("Failed to regenerate query", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to regenerate query: "+err.Error())
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Failed to regenerate query: "+err.Error()).Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	if err := ai.UpdateSavedQueryWithWebsiteAndVega(db, uint(queryID), newTitle, aiResult.SQL, aiResult.QueryType, aiResult.VegaSpec, model, savedQuery.WebsiteID); err != nil {
 		ctx.Logger.Error("Failed to update query", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to update query")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Failed to update query").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
-	flash.SetFlash(ctx.Ctx, "success", "Query updated successfully")
-	return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+	return ctx.FlashSuccess("Query updated successfully").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 }
 
 // WebsiteLensDeleteAction deletes a saved query (POST -> Redirect)
@@ -283,24 +264,20 @@ func WebsiteLensDeleteAction(ctx *cartridge.Context) error {
 	websiteIDStr := ctx.Params("id")
 	websiteID, err := strconv.Atoi(websiteIDStr)
 	if err != nil || websiteID <= 0 {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin/websites", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
 	queryID, _ := strconv.Atoi(ctx.FormValue("id"))
 	if queryID <= 0 {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid query ID")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Invalid query ID").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	if err := ai.DeleteSavedQuery(ctx.DB(), uint(queryID)); err != nil {
 		ctx.Logger.Error("Failed to delete query", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to delete query")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Failed to delete query").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
-	flash.SetFlash(ctx.Ctx, "success", "Query deleted successfully")
-	return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+	return ctx.FlashSuccess("Query deleted successfully").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 }
 
 // WebsiteLensCloneAction clones a saved query (POST -> Redirect)
@@ -308,22 +285,18 @@ func WebsiteLensCloneAction(ctx *cartridge.Context) error {
 	websiteIDStr := ctx.Params("id")
 	websiteID, err := strconv.Atoi(websiteIDStr)
 	if err != nil || websiteID <= 0 {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin/websites", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin/websites", fiber.StatusFound)
 	}
 
 	queryID, _ := strconv.Atoi(ctx.FormValue("id"))
 	if queryID <= 0 {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid query ID")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Invalid query ID").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
 	if _, err := ai.CloneSavedQuery(ctx.DB(), uint(queryID)); err != nil {
 		ctx.Logger.Error("Failed to clone query", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to clone query")
-		return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+		return ctx.FlashError("Failed to clone query").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 	}
 
-	flash.SetFlash(ctx.Ctx, "success", "Query cloned successfully")
-	return ctx.Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
+	return ctx.FlashSuccess("Query cloned successfully").Redirect("/admin/websites/"+websiteIDStr+"/lens", fiber.StatusFound)
 }

--- a/internal/http/onboarding_handler.go
+++ b/internal/http/onboarding_handler.go
@@ -128,11 +128,7 @@ func OnboardingPageAction(ctx *cartridge.Context) error {
 
 // OnboardingUserFormAction handles user account form submission (PRG pattern)
 func OnboardingUserFormAction(ctx *cartridge.Context) error {
-	var in struct {
-		Email string `json:"email" form:"email"`
-	}
-	_ = ctx.Bind(&in)
-	email := strings.TrimSpace(in.Email)
+	email := strings.TrimSpace(ctx.Input("email"))
 
 	// Get session ID from cookie
 	sessionID := ctx.Cookies(onboardingSessionCookieName)
@@ -177,13 +173,8 @@ func OnboardingUserFormAction(ctx *cartridge.Context) error {
 
 // OnboardingPasswordFormAction handles password form submission (PRG pattern)
 func OnboardingPasswordFormAction(ctx *cartridge.Context) error {
-	var in struct {
-		Password        string `json:"password" form:"password"`
-		ConfirmPassword string `json:"confirm_password" form:"confirm_password"`
-	}
-	_ = ctx.Bind(&in)
-	password := in.Password
-	confirmPassword := in.ConfirmPassword
+	password := ctx.Input("password")
+	confirmPassword := ctx.Input("confirm_password")
 
 	// Get session ID from cookie
 	sessionID := ctx.Cookies(onboardingSessionCookieName)

--- a/internal/http/onboarding_handler.go
+++ b/internal/http/onboarding_handler.go
@@ -128,7 +128,11 @@ func OnboardingPageAction(ctx *cartridge.Context) error {
 
 // OnboardingUserFormAction handles user account form submission (PRG pattern)
 func OnboardingUserFormAction(ctx *cartridge.Context) error {
-	email := strings.TrimSpace(ctx.FormValue("email"))
+	var in struct {
+		Email string `json:"email" form:"email"`
+	}
+	_ = ctx.Bind(&in)
+	email := strings.TrimSpace(in.Email)
 
 	// Get session ID from cookie
 	sessionID := ctx.Cookies(onboardingSessionCookieName)
@@ -173,8 +177,13 @@ func OnboardingUserFormAction(ctx *cartridge.Context) error {
 
 // OnboardingPasswordFormAction handles password form submission (PRG pattern)
 func OnboardingPasswordFormAction(ctx *cartridge.Context) error {
-	password := ctx.FormValue("password")
-	confirmPassword := ctx.FormValue("confirm_password")
+	var in struct {
+		Password        string `json:"password" form:"password"`
+		ConfirmPassword string `json:"confirm_password" form:"confirm_password"`
+	}
+	_ = ctx.Bind(&in)
+	password := in.Password
+	confirmPassword := in.ConfirmPassword
 
 	// Get session ID from cookie
 	sessionID := ctx.Cookies(onboardingSessionCookieName)
@@ -282,10 +291,17 @@ func OnboardingGeoLiteFormAction(ctx *cartridge.Context) error {
 	}
 
 	// Get GeoLite credentials from form (optional)
-	action := ctx.FormValue("action")
+	var in struct {
+		Action     string `json:"action" form:"action"`
+		AccountID  string `json:"geolite_account_id" form:"geolite_account_id"`
+		LicenseKey string `json:"geolite_license_key" form:"geolite_license_key"`
+	}
+	_ = ctx.Bind(&in)
+
+	action := in.Action
 	if action != "skip" {
-		accountID := strings.TrimSpace(ctx.FormValue("geolite_account_id"))
-		licenseKey := strings.TrimSpace(ctx.FormValue("geolite_license_key"))
+		accountID := strings.TrimSpace(in.AccountID)
+		licenseKey := strings.TrimSpace(in.LicenseKey)
 
 		// Only save if both fields are provided
 		if accountID != "" && licenseKey != "" {
@@ -334,8 +350,14 @@ func OnboardingOpenAIFormAction(ctx *cartridge.Context) error {
 	}
 
 	// OpenAI key is optional - save it only if the user provided one and did not skip
-	action := ctx.FormValue("action")
-	openAIKey := strings.TrimSpace(ctx.FormValue("openai_key"))
+	var in struct {
+		Action    string `json:"action" form:"action"`
+		OpenAIKey string `json:"openai_key" form:"openai_key"`
+	}
+	_ = ctx.Bind(&in)
+
+	action := in.Action
+	openAIKey := strings.TrimSpace(in.OpenAIKey)
 	if action != "skip" && openAIKey != "" {
 		session.Data.OpenAIKey = openAIKey
 	}

--- a/internal/http/onboarding_handler.go
+++ b/internal/http/onboarding_handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/karloscodes/cartridge"
-	"github.com/karloscodes/cartridge/flash"
 	"github.com/karloscodes/cartridge/inertia"
 	"gorm.io/gorm"
 
@@ -107,16 +106,14 @@ func OnboardingPageAction(ctx *cartridge.Context) error {
 
 	if !required && !forceSetup {
 		// Redirect to login if onboarding is not required
-		flash.SetFlash(ctx.Ctx, "info", "Setup is already complete. Please log in.")
-		return ctx.Redirect("/login", fiber.StatusFound)
+		return ctx.FlashInfo("Setup is already complete. Please log in.").Redirect("/login", fiber.StatusFound)
 	}
 
 	// Get or create onboarding session
 	session, err := GetOrCreateOnboardingSession(ctx, db)
 	if err != nil {
 		ctx.Logger.Error("Failed to get/create onboarding session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to start onboarding session")
-		return ctx.Redirect("/login", fiber.StatusFound)
+		return ctx.FlashError("Failed to start onboarding session").Redirect("/login", fiber.StatusFound)
 	}
 
 	// Build props based on current step
@@ -126,7 +123,7 @@ func OnboardingPageAction(ctx *cartridge.Context) error {
 		"email": session.Data.Email,
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "Onboarding", props)
+	return ctx.Inertia("Onboarding", props)
 }
 
 // OnboardingUserFormAction handles user account form submission (PRG pattern)
@@ -136,8 +133,7 @@ func OnboardingUserFormAction(ctx *cartridge.Context) error {
 	// Get session ID from cookie
 	sessionID := ctx.Cookies(onboardingSessionCookieName)
 	if sessionID == "" {
-		flash.SetFlash(ctx.Ctx, "error", "No active onboarding session")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("No active onboarding session").Redirect("/setup", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -146,26 +142,22 @@ func OnboardingUserFormAction(ctx *cartridge.Context) error {
 	session, err := onboarding.GetOnboardingSession(db, sessionID)
 	if err != nil {
 		ctx.Logger.Error("Failed to get onboarding session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid or expired onboarding session")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Invalid or expired onboarding session").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Validate current step
 	if session.Step != onboarding.StepUserAccount {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid step")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Invalid step").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Validate email
 	if email == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Email is required")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Email is required").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Basic email validation
 	if !strings.Contains(email, "@") || !strings.Contains(email, ".") {
-		flash.SetFlash(ctx.Ctx, "error", "Please enter a valid email address")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Please enter a valid email address").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Update session with email and move to password step
@@ -173,8 +165,7 @@ func OnboardingUserFormAction(ctx *cartridge.Context) error {
 	err = onboarding.UpdateOnboardingSession(db, sessionID, onboarding.StepPassword, session.Data)
 	if err != nil {
 		ctx.Logger.Error("Failed to update onboarding session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to save progress")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Failed to save progress").Redirect("/setup", fiber.StatusFound)
 	}
 
 	return ctx.Redirect("/setup", fiber.StatusFound)
@@ -188,8 +179,7 @@ func OnboardingPasswordFormAction(ctx *cartridge.Context) error {
 	// Get session ID from cookie
 	sessionID := ctx.Cookies(onboardingSessionCookieName)
 	if sessionID == "" {
-		flash.SetFlash(ctx.Ctx, "error", "No active onboarding session")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("No active onboarding session").Redirect("/setup", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -198,30 +188,25 @@ func OnboardingPasswordFormAction(ctx *cartridge.Context) error {
 	session, err := onboarding.GetOnboardingSession(db, sessionID)
 	if err != nil {
 		ctx.Logger.Error("Failed to get onboarding session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid or expired onboarding session")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Invalid or expired onboarding session").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Validate current step
 	if session.Step != onboarding.StepPassword {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid step")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Invalid step").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Validate password
 	if strings.TrimSpace(password) == "" {
-		flash.SetFlash(ctx.Ctx, "error", "Password is required")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Password is required").Redirect("/setup", fiber.StatusFound)
 	}
 
 	if password != confirmPassword {
-		flash.SetFlash(ctx.Ctx, "error", "Passwords do not match")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Passwords do not match").Redirect("/setup", fiber.StatusFound)
 	}
 
 	if len(password) < 8 {
-		flash.SetFlash(ctx.Ctx, "error", "Password must be at least 8 characters long")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Password must be at least 8 characters long").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Update session with password and move to GeoLite step
@@ -229,8 +214,7 @@ func OnboardingPasswordFormAction(ctx *cartridge.Context) error {
 	err = onboarding.UpdateOnboardingSession(db, sessionID, onboarding.StepGeoLite, session.Data)
 	if err != nil {
 		ctx.Logger.Error("Failed to update onboarding session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to save progress")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Failed to save progress").Redirect("/setup", fiber.StatusFound)
 	}
 
 	return ctx.Redirect("/setup", fiber.StatusFound)
@@ -280,8 +264,7 @@ func OnboardingGeoLiteFormAction(ctx *cartridge.Context) error {
 	// Get session ID from cookie
 	sessionID := ctx.Cookies(onboardingSessionCookieName)
 	if sessionID == "" {
-		flash.SetFlash(ctx.Ctx, "error", "No active onboarding session")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("No active onboarding session").Redirect("/setup", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -290,14 +273,12 @@ func OnboardingGeoLiteFormAction(ctx *cartridge.Context) error {
 	session, err := onboarding.GetOnboardingSession(db, sessionID)
 	if err != nil {
 		ctx.Logger.Error("Failed to get onboarding session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid or expired onboarding session")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Invalid or expired onboarding session").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Validate current step
 	if session.Step != onboarding.StepGeoLite {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid step")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Invalid step").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Get GeoLite credentials from form (optional)
@@ -324,8 +305,7 @@ func OnboardingGeoLiteFormAction(ctx *cartridge.Context) error {
 	err = onboarding.UpdateOnboardingSession(db, sessionID, onboarding.StepOpenAI, session.Data)
 	if err != nil {
 		ctx.Logger.Error("Failed to update onboarding session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to save progress")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Failed to save progress").Redirect("/setup", fiber.StatusFound)
 	}
 
 	return ctx.Redirect("/setup", fiber.StatusFound)
@@ -336,8 +316,7 @@ func OnboardingOpenAIFormAction(ctx *cartridge.Context) error {
 	// Get session ID from cookie
 	sessionID := ctx.Cookies(onboardingSessionCookieName)
 	if sessionID == "" {
-		flash.SetFlash(ctx.Ctx, "error", "No active onboarding session")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("No active onboarding session").Redirect("/setup", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -346,14 +325,12 @@ func OnboardingOpenAIFormAction(ctx *cartridge.Context) error {
 	session, err := onboarding.GetOnboardingSession(db, sessionID)
 	if err != nil {
 		ctx.Logger.Error("Failed to get onboarding session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid or expired onboarding session")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Invalid or expired onboarding session").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// Validate current step
 	if session.Step != onboarding.StepOpenAI {
-		flash.SetFlash(ctx.Ctx, "error", "Invalid step")
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Invalid step").Redirect("/setup", fiber.StatusFound)
 	}
 
 	// OpenAI key is optional - save it only if the user provided one and did not skip
@@ -367,10 +344,8 @@ func OnboardingOpenAIFormAction(ctx *cartridge.Context) error {
 	err = completeOnboarding(db, ctx.Logger, ctx.Ctx, ctx.Session, session)
 	if err != nil {
 		ctx.Logger.Error("Failed to complete onboarding", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to complete setup: "+err.Error())
-		return ctx.Redirect("/setup", fiber.StatusFound)
+		return ctx.FlashError("Failed to complete setup: "+err.Error()).Redirect("/setup", fiber.StatusFound)
 	}
 
-	flash.SetFlash(ctx.Ctx, "success", "Setup complete! You have been logged in.")
-	return ctx.Redirect("/admin/websites/new", fiber.StatusFound)
+	return ctx.FlashSuccess("Setup complete! You have been logged in.").Redirect("/admin/websites/new", fiber.StatusFound)
 }

--- a/internal/http/settings_api_handler.go
+++ b/internal/http/settings_api_handler.go
@@ -42,12 +42,8 @@ func validateIPList(ipList string) (bool, string) {
 
 // IngestionSettingsFormAction handles POST form submission for ingestion settings (Inertia)
 func IngestionSettingsFormAction(ctx *cartridge.Context) error {
-	// Bind is content-type aware (form-encoded or Inertia's JSON form.post())
-	var in struct {
-		ExcludedIPs string `json:"excluded_ips" form:"excluded_ips"`
-	}
-	_ = ctx.Bind(&in)
-	excludedIPs := in.ExcludedIPs
+	// Input is content-type aware (form-encoded or Inertia's JSON form.post())
+	excludedIPs := ctx.Input("excluded_ips")
 
 	// Validate IP list
 	if valid, msg := validateIPList(excludedIPs); !valid {

--- a/internal/http/settings_api_handler.go
+++ b/internal/http/settings_api_handler.go
@@ -7,9 +7,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"log/slog"
 
-	"github.com/karloscodes/cartridge"
-	"github.com/karloscodes/cartridge/flash"
 	"fusionaly/internal/settings"
+	"github.com/karloscodes/cartridge"
 )
 
 // validateIPList validates a comma-separated list of IP addresses or CIDR ranges
@@ -43,22 +42,17 @@ func validateIPList(ipList string) (bool, string) {
 
 // IngestionSettingsFormAction handles POST form submission for ingestion settings (Inertia)
 func IngestionSettingsFormAction(ctx *cartridge.Context) error {
-	excludedIPs := ctx.FormValue("excluded_ips")
-	if excludedIPs == "" {
-		// Inertia's form.post() sends JSON, not form-encoded
-		var jsonBody struct {
-			ExcludedIPs string `json:"excluded_ips"`
-		}
-		if err := ctx.BodyParser(&jsonBody); err == nil {
-			excludedIPs = jsonBody.ExcludedIPs
-		}
+	// Bind is content-type aware (form-encoded or Inertia's JSON form.post())
+	var in struct {
+		ExcludedIPs string `json:"excluded_ips" form:"excluded_ips"`
 	}
+	_ = ctx.Bind(&in)
+	excludedIPs := in.ExcludedIPs
 
 	// Validate IP list
 	if valid, msg := validateIPList(excludedIPs); !valid {
 		ctx.Logger.Warn("invalid IP format submitted", slog.String("error", msg))
-		flash.SetFlash(ctx.Ctx, "error", msg)
-		return ctx.Redirect("/admin/administration/ingestion", fiber.StatusFound)
+		return ctx.FlashError(msg).Redirect("/admin/administration/ingestion", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -66,13 +60,11 @@ func IngestionSettingsFormAction(ctx *cartridge.Context) error {
 	// Update setting
 	if err := settings.UpdateSetting(db, "excluded_ips", excludedIPs); err != nil {
 		ctx.Logger.Error("failed to update excluded_ips setting", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to update IP filtering settings")
-		return ctx.Redirect("/admin/administration/ingestion", fiber.StatusFound)
+		return ctx.FlashError("Failed to update IP filtering settings").Redirect("/admin/administration/ingestion", fiber.StatusFound)
 	}
 
 	ctx.Logger.Info("excluded IPs updated via form")
-	flash.SetFlash(ctx.Ctx, "success", "Ingestion settings saved successfully!")
-	return ctx.Redirect("/admin/administration/ingestion", fiber.StatusFound)
+	return ctx.FlashSuccess("Ingestion settings saved successfully!").Redirect("/admin/administration/ingestion", fiber.StatusFound)
 }
 
 // Note: AISettingsFormAction is available in Fusionaly Pro

--- a/internal/http/share_handler.go
+++ b/internal/http/share_handler.go
@@ -78,7 +78,7 @@ func PublicDashboardAction(ctx *cartridge.Context) error {
 		return flowData
 	})
 
-	return inertia.RenderPage(ctx.Ctx, "PublicDashboard", props)
+	return ctx.Inertia("PublicDashboard", props)
 }
 
 // EnableShareAction enables public sharing for a website

--- a/internal/http/system_handler.go
+++ b/internal/http/system_handler.go
@@ -14,10 +14,9 @@ import (
 
 	"fusionaly/internal/config"
 	"fusionaly/internal/jobs"
-	"github.com/karloscodes/cartridge/cache"
-	"github.com/karloscodes/cartridge/flash"
 	"fusionaly/internal/settings"
 	"fusionaly/internal/websites"
+	"github.com/karloscodes/cartridge/cache"
 )
 
 // SystemExportDatabaseAction exports the SQLite database file
@@ -102,7 +101,7 @@ func AdministrationIngestionPageAction(ctx *cartridge.Context) error {
 		websitesData = []map[string]interface{}{}
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "AdministrationIngestion", inertia.Props{
+	return ctx.Inertia("AdministrationIngestion", inertia.Props{
 		"settings": settingsData,
 		"websites": websitesData,
 	})
@@ -126,7 +125,7 @@ func AdministrationAccountPageAction(ctx *cartridge.Context) error {
 		websitesData = []map[string]interface{}{}
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "AdministrationAccount", inertia.Props{
+	return ctx.Inertia("AdministrationAccount", inertia.Props{
 		"settings": settingsData,
 		"websites": websitesData,
 	})
@@ -153,7 +152,7 @@ func AdministrationAgentsPageAction(ctx *cartridge.Context) error {
 		}
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "AdministrationAgents", inertia.Props{
+	return ctx.Inertia("AdministrationAgents", inertia.Props{
 		"websites":             websitesData,
 		"agent_api_key":        maskedAPIKey,
 		"agent_api_key_exists": agentAPIKey != "",
@@ -223,7 +222,7 @@ func AdministrationSystemPageAction(ctx *cartridge.Context) error {
 	_, geoDBErr := os.Stat(geoDBPath)
 	geoDBExists := geoDBErr == nil
 
-	return inertia.RenderPage(ctx.Ctx, "AdministrationSystem", inertia.Props{
+	return ctx.Inertia("AdministrationSystem", inertia.Props{
 		"websites":               websitesData,
 		"show_logs":              showLogs,
 		"logs":                   logs,
@@ -304,40 +303,30 @@ func SystemPurgeCacheFormAction(ctx *cartridge.Context) error {
 	rowsAffected, err := cache.PurgeAllCaches(db)
 	if err != nil {
 		ctx.Logger.Error("Failed to clear generic_cache", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to clear caches")
-		return ctx.Redirect("/admin/administration/system", fiber.StatusFound)
+		return ctx.FlashError("Failed to clear caches").Redirect("/admin/administration/system", fiber.StatusFound)
 	}
 
 	ctx.Logger.Info("Caches purged successfully", slog.Int64("rows_deleted", rowsAffected))
-	flash.SetFlash(ctx.Ctx, "success", "All caches have been purged successfully")
-	return ctx.Redirect("/admin/administration/system", fiber.StatusFound)
+	return ctx.FlashSuccess("All caches have been purged successfully").Redirect("/admin/administration/system", fiber.StatusFound)
 }
 
 // SystemGeoLiteFormAction handles POST form submission for GeoLite settings (Inertia)
 func SystemGeoLiteFormAction(ctx *cartridge.Context) error {
 	db := ctx.DB()
 
-	// Parse form data - try both form value and JSON body (for Inertia.js)
-	accountID := ctx.FormValue("geolite_account_id")
-	licenseKey := ctx.FormValue("geolite_license_key")
-
-	// Try parsing as JSON for Inertia.js requests
-	if accountID == "" && licenseKey == "" {
-		var jsonBody struct {
-			AccountID  string `json:"geolite_account_id"`
-			LicenseKey string `json:"geolite_license_key"`
-		}
-		if err := ctx.BodyParser(&jsonBody); err == nil {
-			accountID = jsonBody.AccountID
-			licenseKey = jsonBody.LicenseKey
-		}
+	// Parse form data - Bind is content-type aware (form-encoded or Inertia.js JSON)
+	var in struct {
+		AccountID  string `json:"geolite_account_id" form:"geolite_account_id"`
+		LicenseKey string `json:"geolite_license_key" form:"geolite_license_key"`
 	}
+	_ = ctx.Bind(&in)
+	accountID := in.AccountID
+	licenseKey := in.LicenseKey
 
 	// Save GeoLite credentials
 	if err := settings.SaveGeoLiteCredentials(db, accountID, licenseKey); err != nil {
 		ctx.Logger.Error("Failed to save GeoLite settings", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to save GeoLite settings")
-		return ctx.Redirect("/admin/administration/system", fiber.StatusFound)
+		return ctx.FlashError("Failed to save GeoLite settings").Redirect("/admin/administration/system", fiber.StatusFound)
 	}
 
 	ctx.Logger.Info("GeoLite settings updated",
@@ -348,11 +337,9 @@ func SystemGeoLiteFormAction(ctx *cartridge.Context) error {
 	if accountID != "" && licenseKey != "" {
 		cfg := ctx.Config.(*config.Config)
 		jobs.TriggerImmediateDownload(db, ctx.Logger, cfg)
-		flash.SetFlash(ctx.Ctx, "success", "GeoLite settings saved. Database download started in the background.")
-	} else {
-		flash.SetFlash(ctx.Ctx, "success", "GeoLite settings saved successfully")
+		return ctx.FlashSuccess("GeoLite settings saved. Database download started in the background.").Redirect("/admin/administration/system", fiber.StatusFound)
 	}
-	return ctx.Redirect("/admin/administration/system", fiber.StatusFound)
+	return ctx.FlashSuccess("GeoLite settings saved successfully").Redirect("/admin/administration/system", fiber.StatusFound)
 }
 
 // SystemGeoLiteDownloadAction triggers an immediate GeoLite database download (Inertia)
@@ -362,8 +349,7 @@ func SystemGeoLiteDownloadAction(ctx *cartridge.Context) error {
 	// Check if credentials are configured
 	accountID, licenseKey, _ := settings.GetGeoLiteCredentials(db)
 	if accountID == "" || licenseKey == "" {
-		flash.SetFlash(ctx.Ctx, "error", "GeoLite credentials not configured. Please enter your Account ID and License Key first.")
-		return ctx.Redirect("/admin/administration/system", fiber.StatusFound)
+		return ctx.FlashError("GeoLite credentials not configured. Please enter your Account ID and License Key first.").Redirect("/admin/administration/system", fiber.StatusFound)
 	}
 
 	// Trigger immediate download
@@ -371,8 +357,7 @@ func SystemGeoLiteDownloadAction(ctx *cartridge.Context) error {
 	jobs.TriggerImmediateDownload(db, ctx.Logger, cfg)
 
 	ctx.Logger.Info("Manual GeoLite database download triggered")
-	flash.SetFlash(ctx.Ctx, "success", "Database download started in the background. Refresh this page in a moment to check status.")
-	return ctx.Redirect("/admin/administration/system", fiber.StatusFound)
+	return ctx.FlashSuccess("Database download started in the background. Refresh this page in a moment to check status.").Redirect("/admin/administration/system", fiber.StatusFound)
 }
 
 // SystemAgentAPIKeyAction returns or creates the Agent API key (JSON response)
@@ -399,11 +384,9 @@ func SystemAgentAPIKeyRegenerateAction(ctx *cartridge.Context) error {
 	_, err := settings.RegenerateAgentAPIKey(db)
 	if err != nil {
 		ctx.Logger.Error("Failed to regenerate Agent API key", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to regenerate API key")
-		return ctx.Redirect("/admin/administration/agents", fiber.StatusFound)
+		return ctx.FlashError("Failed to regenerate API key").Redirect("/admin/administration/agents", fiber.StatusFound)
 	}
 
 	ctx.Logger.Info("Agent API key regenerated")
-	flash.SetFlash(ctx.Ctx, "success", "API key regenerated successfully. Copy your new key - it won't be shown again in full.")
-	return ctx.Redirect("/admin/administration/agents", fiber.StatusFound)
+	return ctx.FlashSuccess("API key regenerated successfully. Copy your new key - it won't be shown again in full.").Redirect("/admin/administration/agents", fiber.StatusFound)
 }

--- a/internal/http/system_handler.go
+++ b/internal/http/system_handler.go
@@ -314,14 +314,9 @@ func SystemPurgeCacheFormAction(ctx *cartridge.Context) error {
 func SystemGeoLiteFormAction(ctx *cartridge.Context) error {
 	db := ctx.DB()
 
-	// Parse form data - Bind is content-type aware (form-encoded or Inertia.js JSON)
-	var in struct {
-		AccountID  string `json:"geolite_account_id" form:"geolite_account_id"`
-		LicenseKey string `json:"geolite_license_key" form:"geolite_license_key"`
-	}
-	_ = ctx.Bind(&in)
-	accountID := in.AccountID
-	licenseKey := in.LicenseKey
+	// Parse form data - Input is content-type aware (form-encoded or Inertia.js JSON)
+	accountID := ctx.Input("geolite_account_id")
+	licenseKey := ctx.Input("geolite_license_key")
 
 	// Save GeoLite credentials
 	if err := settings.SaveGeoLiteCredentials(db, accountID, licenseKey); err != nil {

--- a/internal/http/users_handler.go
+++ b/internal/http/users_handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/karloscodes/cartridge"
 	"github.com/karloscodes/cartridge/crypto"
 	"github.com/karloscodes/cartridge/inertia"
-	"github.com/karloscodes/cartridge/flash"
 	"log/slog"
 
 	"fusionaly/internal/onboarding"
@@ -34,40 +33,25 @@ func RenderLoginAction(ctx *cartridge.Context) error {
 	}
 
 	// Render the login page using Inertia (csrfToken and flash auto-injected)
-	return inertia.RenderPage(ctx.Ctx, "Login", inertia.Props{})
+	return ctx.Inertia("Login", inertia.Props{})
 }
 
 // ProcessLoginAction handles the login form submission
 func ProcessLoginAction(ctx *cartridge.Context) error {
-	// Parse login form - try both form value and JSON body (for Inertia.js)
-	email := ctx.FormValue("email")
-	password := ctx.FormValue("password")
-	tz := ctx.FormValue("_tz")
-
-	// Try parsing as JSON for Inertia.js requests
-	if email == "" && password == "" {
-		var jsonBody struct {
-			Email    string `json:"email"`
-			Password string `json:"password"`
-			Tz       string `json:"_tz"`
-		}
-		if err := ctx.BodyParser(&jsonBody); err == nil {
-			if jsonBody.Email != "" {
-				email = jsonBody.Email
-			}
-			if jsonBody.Password != "" {
-				password = jsonBody.Password
-			}
-			if jsonBody.Tz != "" {
-				tz = jsonBody.Tz
-			}
-		}
+	// Parse login form - Bind is content-type aware (form-encoded or Inertia.js JSON)
+	var in struct {
+		Email    string `json:"email" form:"email"`
+		Password string `json:"password" form:"password"`
+		Tz       string `json:"_tz" form:"_tz"`
 	}
+	_ = ctx.Bind(&in)
+	email := in.Email
+	password := in.Password
+	tz := in.Tz
 
 	if email == "" || password == "" {
 		// Set flash error message and redirect to login page
-		flash.SetFlash(ctx.Ctx, "error", "Email and password are required")
-		return ctx.Redirect("/login", fiber.StatusFound)
+		return ctx.FlashError("Email and password are required").Redirect("/login", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -98,15 +82,13 @@ func ProcessLoginAction(ctx *cartridge.Context) error {
 	// Check if authentication failed (either user not found or wrong password)
 	if !passwordValid {
 		// Generic error message - don't reveal whether email exists
-		flash.SetFlash(ctx.Ctx, "error", "Invalid email or password")
-		return ctx.Redirect("/login", fiber.StatusFound)
+		return ctx.FlashError("Invalid email or password").Redirect("/login", fiber.StatusFound)
 	}
 
 	// Set session cookie
 	if err := ctx.Session.SetSession(ctx.Ctx, user.ID); err != nil {
 		ctx.Logger.Error("Failed to set session", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Login failed")
-		return ctx.Redirect("/login", fiber.StatusFound)
+		return ctx.FlashError("Login failed").Redirect("/login", fiber.StatusFound)
 	}
 	ctx.Logger.Debug("Login successful",
 		slog.String("email", email),
@@ -157,11 +139,8 @@ func LogoutAction(ctx *cartridge.Context) error {
 		SameSite: "Lax",
 	})
 
-	// Set a flash message
-	flash.SetFlash(ctx.Ctx, "success", "You have been successfully logged out")
-
 	ctx.Logger.Debug("LogoutAction: User logged out, redirecting to login page")
 
-	// Return a redirect to /login
-	return ctx.Redirect("/login", fiber.StatusFound)
+	// Set a flash message and redirect to /login
+	return ctx.FlashSuccess("You have been successfully logged out").Redirect("/login", fiber.StatusFound)
 }

--- a/internal/http/websites_handler.go
+++ b/internal/http/websites_handler.go
@@ -58,12 +58,8 @@ func WebsiteNewPageAction(ctx *cartridge.Context) error {
 
 // WebsiteCreateAction handles creating a new website (form submission)
 func WebsiteCreateAction(ctx *cartridge.Context) error {
-	// Bind is content-type aware (form-encoded or Inertia.js JSON)
-	var in struct {
-		Domain string `json:"domain" form:"domain"`
-	}
-	_ = ctx.Bind(&in)
-	domain := in.Domain
+	// Input is content-type aware (form-encoded or Inertia.js JSON)
+	domain := ctx.Input("domain")
 
 	// Validate domain
 	if domain == "" {
@@ -180,14 +176,9 @@ func WebsiteUpdateAction(ctx *cartridge.Context) error {
 		return ctx.FlashError("Invalid website ID").Redirect("/admin", fiber.StatusFound)
 	}
 
-	// Parse form data - Bind is content-type aware (form-encoded or Inertia.js JSON)
-	var in struct {
-		ConversionGoals          string `json:"conversion_goals" form:"conversion_goals"`
-		SubdomainTrackingEnabled string `json:"subdomain_tracking_enabled" form:"subdomain_tracking_enabled"`
-	}
-	_ = ctx.Bind(&in)
-	conversionGoalsJSON := in.ConversionGoals
-	subdomainTrackingEnabledStr := in.SubdomainTrackingEnabled
+	// Parse form data - Input is content-type aware (form-encoded or Inertia.js JSON)
+	conversionGoalsJSON := ctx.Input("conversion_goals")
+	subdomainTrackingEnabledStr := ctx.Input("subdomain_tracking_enabled")
 
 	subdomainTrackingEnabled := subdomainTrackingEnabledStr == "true"
 

--- a/internal/http/websites_handler.go
+++ b/internal/http/websites_handler.go
@@ -58,30 +58,15 @@ func WebsiteNewPageAction(ctx *cartridge.Context) error {
 
 // WebsiteCreateAction handles creating a new website (form submission)
 func WebsiteCreateAction(ctx *cartridge.Context) error {
-	// Log form submission details for debugging
-	ctx.Logger.Info("Received website creation form submission",
-		slog.String("method", ctx.Method()),
-		slog.String("content_type", ctx.Get("Content-Type")),
-		slog.String("raw_body", string(ctx.Body())),
-		slog.String("csrf_token", ctx.FormValue("_csrf")),
-		slog.String("domain", ctx.FormValue("domain")),
-	)
-
-	// Parse form data - Bind is content-type aware (form-encoded or Inertia.js JSON)
+	// Bind is content-type aware (form-encoded or Inertia.js JSON)
 	var in struct {
 		Domain string `json:"domain" form:"domain"`
 	}
 	_ = ctx.Bind(&in)
 	domain := in.Domain
 
-	// Log form values
-	ctx.Logger.Info("Form values",
-		slog.String("domain", domain),
-	)
-
 	// Validate domain
 	if domain == "" {
-		ctx.Logger.Warn("Domain field is empty")
 		return ctx.FlashError("Domain is required").Redirect("/admin/websites/new", fiber.StatusFound)
 	}
 
@@ -92,8 +77,7 @@ func WebsiteCreateAction(ctx *cartridge.Context) error {
 		Domain: domain,
 	}
 
-	// Log attempt to create website
-	ctx.Logger.Info("Attempting to create website", slog.String("domain", domain))
+	ctx.Logger.Info("Creating website", slog.String("domain", domain))
 
 	if err := websites.CreateWebsite(db, &website); err != nil {
 		ctx.Logger.Error("Failed to create website", slog.Any("error", err), slog.String("domain", domain))

--- a/internal/http/websites_handler.go
+++ b/internal/http/websites_handler.go
@@ -5,15 +5,14 @@ import (
 	"strconv"
 
 	"github.com/gofiber/fiber/v2"
-	"log/slog"
 	"gorm.io/gorm"
+	"log/slog"
 
 	"fusionaly/internal/events"
-	"github.com/karloscodes/cartridge"
-	"github.com/karloscodes/cartridge/flash"
-	"github.com/karloscodes/cartridge/inertia"
 	"fusionaly/internal/settings"
 	"fusionaly/internal/websites"
+	"github.com/karloscodes/cartridge"
+	"github.com/karloscodes/cartridge/inertia"
 )
 
 // WebsitesIndexAction handles listing all websites (Inertia)
@@ -24,8 +23,7 @@ func WebsitesIndexAction(ctx *cartridge.Context) error {
 	websitesWithCounts, err := websites.GetWebsitesWithStats(db, 30)
 	if err != nil {
 		ctx.Logger.Error("Failed to get websites with stats", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to load websites")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Failed to load websites").Redirect("/admin", fiber.StatusFound)
 	}
 
 	// If no websites exist, redirect to the creation page
@@ -34,7 +32,7 @@ func WebsitesIndexAction(ctx *cartridge.Context) error {
 		return ctx.Redirect("/admin/websites/new", fiber.StatusFound)
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "Websites", inertia.Props{
+	return ctx.Inertia("Websites", inertia.Props{
 		"title":    "Websites",
 		"websites": websitesWithCounts,
 	})
@@ -52,7 +50,7 @@ func WebsiteNewPageAction(ctx *cartridge.Context) error {
 		websitesData = []map[string]interface{}{} // Ensure it's an empty slice, not nil
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "WebsiteNew", inertia.Props{
+	return ctx.Inertia("WebsiteNew", inertia.Props{
 		"title":    "New Website",
 		"websites": websitesData,
 	})
@@ -69,17 +67,12 @@ func WebsiteCreateAction(ctx *cartridge.Context) error {
 		slog.String("domain", ctx.FormValue("domain")),
 	)
 
-	// Parse form data - try both form value and JSON body (for Inertia.js)
-	domain := ctx.FormValue("domain")
-	if domain == "" {
-		// Try parsing as JSON for Inertia.js requests
-		var jsonBody struct {
-			Domain string `json:"domain"`
-		}
-		if err := ctx.BodyParser(&jsonBody); err == nil && jsonBody.Domain != "" {
-			domain = jsonBody.Domain
-		}
+	// Parse form data - Bind is content-type aware (form-encoded or Inertia.js JSON)
+	var in struct {
+		Domain string `json:"domain" form:"domain"`
 	}
+	_ = ctx.Bind(&in)
+	domain := in.Domain
 
 	// Log form values
 	ctx.Logger.Info("Form values",
@@ -89,8 +82,7 @@ func WebsiteCreateAction(ctx *cartridge.Context) error {
 	// Validate domain
 	if domain == "" {
 		ctx.Logger.Warn("Domain field is empty")
-		flash.SetFlash(ctx.Ctx, "error", "Domain is required")
-		return ctx.Redirect("/admin/websites/new", fiber.StatusFound)
+		return ctx.FlashError("Domain is required").Redirect("/admin/websites/new", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -105,8 +97,7 @@ func WebsiteCreateAction(ctx *cartridge.Context) error {
 
 	if err := websites.CreateWebsite(db, &website); err != nil {
 		ctx.Logger.Error("Failed to create website", slog.Any("error", err), slog.String("domain", domain))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to create website: "+err.Error())
-		return ctx.Redirect("/admin/websites/new", fiber.StatusFound)
+		return ctx.FlashError("Failed to create website: "+err.Error()).Redirect("/admin/websites/new", fiber.StatusFound)
 	}
 
 	// Log success
@@ -115,8 +106,7 @@ func WebsiteCreateAction(ctx *cartridge.Context) error {
 		slog.String("domain", website.Domain))
 
 	// Success - redirect to setup page
-	flash.SetFlash(ctx.Ctx, "success", "Website created successfully")
-	return ctx.Redirect("/admin/websites/"+strconv.Itoa(int(website.ID))+"/setup", fiber.StatusFound)
+	return ctx.FlashSuccess("Website created successfully").Redirect("/admin/websites/"+strconv.Itoa(int(website.ID))+"/setup", fiber.StatusFound)
 }
 
 // WebsiteSetupPageAction handles showing the website setup page after creation (Inertia)
@@ -134,14 +124,13 @@ func WebsiteSetupPageAction(ctx *cartridge.Context) error {
 	website, err := websites.GetWebsiteByID(db, uint(id))
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			flash.SetFlash(ctx.Ctx, "error", "Website not found")
-			return ctx.Redirect("/admin", fiber.StatusFound)
+			return ctx.FlashError("Website not found").Redirect("/admin", fiber.StatusFound)
 		}
 		ctx.Logger.Error("Failed to get website", slog.Any("error", err), slog.Int("id", id))
 		return ctx.Redirect("/admin", fiber.StatusFound)
 	}
 
-	return inertia.RenderPage(ctx.Ctx, "WebsiteSetup", inertia.Props{
+	return ctx.Inertia("WebsiteSetup", inertia.Props{
 		"website": inertia.Props{
 			"id":     website.ID,
 			"domain": website.Domain,
@@ -155,8 +144,7 @@ func WebsiteEditPageAction(ctx *cartridge.Context) error {
 	id, err := ctx.ParamsInt("id")
 	if err != nil {
 		ctx.Logger.Error("Invalid website ID", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -165,12 +153,10 @@ func WebsiteEditPageAction(ctx *cartridge.Context) error {
 	website, err := websites.GetWebsiteByID(db, uint(id))
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			flash.SetFlash(ctx.Ctx, "error", "Website not found")
-			return ctx.Redirect("/admin", fiber.StatusFound)
+			return ctx.FlashError("Website not found").Redirect("/admin", fiber.StatusFound)
 		}
 		ctx.Logger.Error("Failed to get website", slog.Any("error", err), slog.Int("id", id))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to load website")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Failed to load website").Redirect("/admin", fiber.StatusFound)
 	}
 
 	// Fetch all distinct events for this website
@@ -192,7 +178,7 @@ func WebsiteEditPageAction(ctx *cartridge.Context) error {
 	// Fetch subdomain tracking setting for this website
 	subdomainTrackingEnabled := settings.IsSubdomainTrackingEnabled(db, website.Domain)
 
-	return inertia.RenderPage(ctx.Ctx, "WebsiteEdit", inertia.Props{
+	return ctx.Inertia("WebsiteEdit", inertia.Props{
 		"title":                      "Edit Website",
 		"website":                    website,
 		"all_distinct_events":        allDistinctEvents,
@@ -207,29 +193,17 @@ func WebsiteUpdateAction(ctx *cartridge.Context) error {
 	id, err := ctx.ParamsInt("id")
 	if err != nil {
 		ctx.Logger.Error("Invalid website ID", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin", fiber.StatusFound)
 	}
 
-	// Parse form data - try both form value and JSON body (for Inertia.js)
-	conversionGoalsJSON := ctx.FormValue("conversion_goals")
-	subdomainTrackingEnabledStr := ctx.FormValue("subdomain_tracking_enabled")
-
-	// Try parsing as JSON for Inertia.js requests
-	if conversionGoalsJSON == "" {
-		var jsonBody struct {
-			ConversionGoals          string `json:"conversion_goals"`
-			SubdomainTrackingEnabled string `json:"subdomain_tracking_enabled"`
-		}
-		if err := ctx.BodyParser(&jsonBody); err == nil {
-			if jsonBody.ConversionGoals != "" {
-				conversionGoalsJSON = jsonBody.ConversionGoals
-			}
-			if jsonBody.SubdomainTrackingEnabled != "" {
-				subdomainTrackingEnabledStr = jsonBody.SubdomainTrackingEnabled
-			}
-		}
+	// Parse form data - Bind is content-type aware (form-encoded or Inertia.js JSON)
+	var in struct {
+		ConversionGoals          string `json:"conversion_goals" form:"conversion_goals"`
+		SubdomainTrackingEnabled string `json:"subdomain_tracking_enabled" form:"subdomain_tracking_enabled"`
 	}
+	_ = ctx.Bind(&in)
+	conversionGoalsJSON := in.ConversionGoals
+	subdomainTrackingEnabledStr := in.SubdomainTrackingEnabled
 
 	subdomainTrackingEnabled := subdomainTrackingEnabledStr == "true"
 
@@ -240,12 +214,10 @@ func WebsiteUpdateAction(ctx *cartridge.Context) error {
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			ctx.Logger.Warn("Website not found", slog.Int("id", id))
-			flash.SetFlash(ctx.Ctx, "error", "Website not found")
-			return ctx.Redirect("/admin", fiber.StatusFound)
+			return ctx.FlashError("Website not found").Redirect("/admin", fiber.StatusFound)
 		}
 		ctx.Logger.Error("Failed to get website", slog.Any("error", err), slog.Int("id", id))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to update website")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Failed to update website").Redirect("/admin", fiber.StatusFound)
 	}
 
 	ctx.Logger.Info("Updating website settings",
@@ -258,8 +230,7 @@ func WebsiteUpdateAction(ctx *cartridge.Context) error {
 		var goals []string
 		if err := json.Unmarshal([]byte(conversionGoalsJSON), &goals); err != nil {
 			ctx.Logger.Error("Failed to parse conversion goals", slog.Any("error", err), slog.String("json", conversionGoalsJSON))
-			flash.SetFlash(ctx.Ctx, "error", "Invalid conversion goals format")
-			return ctx.Redirect("/admin/websites/"+strconv.Itoa(id)+"/edit", fiber.StatusFound)
+			return ctx.FlashError("Invalid conversion goals format").Redirect("/admin/websites/"+strconv.Itoa(id)+"/edit", fiber.StatusFound)
 		}
 
 		ctx.Logger.Info("Parsed goals", slog.Any("goals", goals))
@@ -267,8 +238,7 @@ func WebsiteUpdateAction(ctx *cartridge.Context) error {
 		// Save goals for this website
 		if err := settings.SaveWebsiteGoals(db, uint(id), goals); err != nil {
 			ctx.Logger.Error("Failed to save conversion goals", slog.Any("error", err), slog.Int("id", id))
-			flash.SetFlash(ctx.Ctx, "error", "Failed to save conversion goals")
-			return ctx.Redirect("/admin/websites/"+strconv.Itoa(id)+"/edit", fiber.StatusFound)
+			return ctx.FlashError("Failed to save conversion goals").Redirect("/admin/websites/"+strconv.Itoa(id)+"/edit", fiber.StatusFound)
 		}
 	} else {
 		ctx.Logger.Warn("No conversion goals JSON provided in form submission")
@@ -278,13 +248,11 @@ func WebsiteUpdateAction(ctx *cartridge.Context) error {
 	ctx.Logger.Info("Processing subdomain tracking setting", slog.Bool("enabled", subdomainTrackingEnabled), slog.String("domain", website.Domain))
 	if err := settings.UpdateSubdomainTrackingSettings(db, website.Domain, subdomainTrackingEnabled); err != nil {
 		ctx.Logger.Error("Failed to update subdomain tracking setting", slog.Any("error", err), slog.String("domain", website.Domain))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to update subdomain tracking setting")
-		return ctx.Redirect("/admin/websites/"+strconv.Itoa(id)+"/edit", fiber.StatusFound)
+		return ctx.FlashError("Failed to update subdomain tracking setting").Redirect("/admin/websites/"+strconv.Itoa(id)+"/edit", fiber.StatusFound)
 	}
 
 	// Success - redirect back to the edit page
-	flash.SetFlash(ctx.Ctx, "success", "Website updated successfully")
-	return ctx.Redirect("/admin/websites/"+strconv.Itoa(id)+"/edit", fiber.StatusFound)
+	return ctx.FlashSuccess("Website updated successfully").Redirect("/admin/websites/"+strconv.Itoa(id)+"/edit", fiber.StatusFound)
 }
 
 // WebsiteDeleteAction handles deleting a website (form submission)
@@ -293,8 +261,7 @@ func WebsiteDeleteAction(ctx *cartridge.Context) error {
 	id, err := ctx.ParamsInt("id")
 	if err != nil {
 		ctx.Logger.Error("Invalid website ID", slog.Any("error", err))
-		flash.SetFlash(ctx.Ctx, "error", "Invalid website ID")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Invalid website ID").Redirect("/admin", fiber.StatusFound)
 	}
 
 	db := ctx.DB()
@@ -302,15 +269,12 @@ func WebsiteDeleteAction(ctx *cartridge.Context) error {
 	// Delete website
 	if err := websites.DeleteWebsite(db, uint(id)); err != nil {
 		if err == gorm.ErrRecordNotFound {
-			flash.SetFlash(ctx.Ctx, "error", "Website not found")
-			return ctx.Redirect("/admin", fiber.StatusFound)
+			return ctx.FlashError("Website not found").Redirect("/admin", fiber.StatusFound)
 		}
 		ctx.Logger.Error("Failed to delete website", slog.Any("error", err), slog.Int("id", id))
-		flash.SetFlash(ctx.Ctx, "error", "Failed to delete website")
-		return ctx.Redirect("/admin", fiber.StatusFound)
+		return ctx.FlashError("Failed to delete website").Redirect("/admin", fiber.StatusFound)
 	}
 
 	// Success - redirect to websites list
-	flash.SetFlash(ctx.Ctx, "success", "Website deleted successfully")
-	return ctx.Redirect("/admin", fiber.StatusFound)
+	return ctx.FlashSuccess("Website deleted successfully").Redirect("/admin", fiber.StatusFound)
 }


### PR DESCRIPTION
Refactors HTTP handlers to the new cartridge helpers — `ctx.Bind` (content-type-aware input), `ctx.Inertia` (render + auto-flash), and `ctx.FlashError/Success/Info(...).Redirect(...)`. Behavior-preserving; bug-prone FormValue+BodyParser fallbacks replaced with typed `Bind` structs. Risky cases (param/form id collision in lens, native HTML onboarding forms, agent JSON API) intentionally left as-is.