### PR TITLE
deps(web): remove unused react-icons

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -27,7 +27,6 @@
         "react": "^19.0.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "^19.0.0",
-        "react-icons": "^5.4.0",
         "react-vega": "^8.0.0",
         "recharts": "^2.15.1",
         "sonner": "^2.0.5",
@@ -5422,15 +5421,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
-      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,6 @@
     "react": "^19.0.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.4.0",
     "react-vega": "^8.0.0",
     "recharts": "^2.15.1",
     "sonner": "^2.0.5",


### PR DESCRIPTION
Zero imports anywhere in web/src; 83 MB installed. Pure supply-chain
surface for no value.
