### PR TITLE
fix(jobs): don't block event processing when GeoLite isn't configured

### DIFF
--- a/internal/jobs/event_processor.go
+++ b/internal/jobs/event_processor.go
@@ -3,35 +3,31 @@ package jobs
 import (
 	"log/slog"
 
+	"github.com/karloscodes/cartridge"
+
 	"fusionaly/internal/analytics"
-	"fusionaly/internal/database"
 	"fusionaly/internal/events"
-	"fusionaly/internal/pkg/geoip"
 )
 
 // EventProcessorJob handles processing of ingested events
 type EventProcessorJob struct {
-	dbManager *database.DBManager
+	dbManager cartridge.DBManager
 	logger    *slog.Logger
 }
 
-func NewEventProcessorJob(dbManager *database.DBManager, logger *slog.Logger) *EventProcessorJob {
+func NewEventProcessorJob(dbManager cartridge.DBManager, logger *slog.Logger) *EventProcessorJob {
 	return &EventProcessorJob{
 		dbManager: dbManager,
 		logger:    logger,
 	}
 }
 
-// Run processes unprocessed events from the ingest database
+// Run processes unprocessed events from the ingest database.
+// Country data is resolved at ingestion time (events.GetCountryFromIP), which
+// already degrades gracefully to "Unknown" when no GeoLite database is
+// configured, so processing must not be blocked on GeoLite availability.
 func (j *EventProcessorJob) Run() error {
 	j.logger.Info("Starting event processing")
-
-	// Check if GeoLite database is available - required for event processing
-	if geoip.GetGeoDB() == nil {
-		j.logger.Warn("GeoLite database not configured - events will remain queued. " +
-			"Configure GeoLite in Administration > System or set FUSIONALY_GEO_DB_PATH")
-		return nil
-	}
 
 	db := j.dbManager.GetConnection()
 

--- a/internal/jobs/event_processor_test.go
+++ b/internal/jobs/event_processor_test.go
@@ -1,0 +1,49 @@
+package jobs_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"fusionaly/internal/events"
+	"fusionaly/internal/jobs"
+	"fusionaly/internal/testsupport"
+)
+
+func TestEventProcessorJob(t *testing.T) {
+	t.Run("processes queued events even when GeoLite is not configured", func(t *testing.T) {
+		dbManager, logger, website := testsupport.SetupTestDBManagerWithWebsite(t, "example.com")
+		db := dbManager.GetConnection()
+
+		now := time.Now().UTC()
+		ingested := events.IngestedEvent{
+			WebsiteID:        website.ID,
+			UserSignature:    "test-signature",
+			Hostname:         "example.com",
+			Pathname:         "/",
+			ReferrerHostname: events.DirectOrUnknownReferrer,
+			EventType:        events.EventTypePageView,
+			Timestamp:        now,
+			UserAgent:        "Mozilla/5.0 (Test Agent)",
+			RawURL:           "https://example.com/",
+			Processed:        0,
+			CreatedAt:        now,
+		}
+		require.NoError(t, db.Create(&ingested).Error)
+
+		job := jobs.NewEventProcessorJob(dbManager, logger)
+
+		err := job.Run()
+
+		require.NoError(t, err)
+		var processedCount int64
+		require.NoError(t, db.Model(&events.IngestedEvent{}).Where("processed = 1").Count(&processedCount).Error)
+		assert.Equal(t, int64(1), processedCount, "queued event should have been processed")
+
+		var eventCount int64
+		require.NoError(t, db.Model(&events.Event{}).Count(&eventCount).Error)
+		assert.Equal(t, int64(1), eventCount, "processed event should have been written to the Event table")
+	})
+}


### PR DESCRIPTION
Fixes #75